### PR TITLE
Fix logo source path on RLSS competitions page

### DIFF
--- a/resources/views/competitions/rlss.blade.php
+++ b/resources/views/competitions/rlss.blade.php
@@ -10,7 +10,7 @@ RLSS Competitions |
 
   <div class="h-full w-full overflow-hidden relative">
     <div class="absolute top-0 right-0 w-full h-full head-bg-3 flex items-center justify-center ">
-      <img src="/storage/logo/blogo.png" class="w-[10%] hidden md:block" alt="">
+      <img src="/storage/logo/rlss_logo.png" class="w-[10%] hidden md:block" alt="">
       <div class="md:border-l-2 border-white md:ml-12 md:pl-12 py-8">
         <h2 class="md:text-6xl text-4xl font-bold text-white">RLSS Competitions</h2>
         <p class="text-white">More opportunities to do lifesaving!</p>


### PR DESCRIPTION
Update the logo source path to correctly display the RLSS logo on the competitions page.